### PR TITLE
Fix Terminal output, Add README info, remove hours and seconds settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,32 @@ A Ruby powered command line app for sending timed messages to slack channels
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'slack_pomodoro_timer'
-```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
     $ gem install slack_pomodoro_timer
+
+Configure your Slackbot url:
+
+    $ slack_pomodoro_timer config --url https://company.slack.com/services/hooks/slackbot?token=thisisyourtoken
+
+Configure the channel into which you would like to post (this defaults to the general channel):
+
+    $ slack_pomodoro_timer config --channel my_channel
+
+You do not need to prepend your channel name with a # symbol, but if absolutely must, then make sure to wrap your channel name in quotes:
+
+    $ slack_pomodoro_timer config --channel "#my_channel"
 
 ## Usage
 
+To run 5 consecutive 25 minute Pomodoros:
+
+    $ slack_pomodoro_timer start 5
+
+Here's how to use a custom pomodoro length:
+
+    $ slack_pomodoro_timer start 5 --minutes 10
 
 Still a work in progress, however there are minimal passing tests.
 To run the tests you can simply run `$ rspec` or use Guard with `$ bundle exec guard`.
-
-See the inline documentation for `timer.rb` and `http.rb` for more information on what is happening internally.
-
 
 ## Development
 

--- a/lib/slack_pomodoro_timer/cli.rb
+++ b/lib/slack_pomodoro_timer/cli.rb
@@ -5,13 +5,12 @@ require 'thor'
 # Config the timer
 # slack_pomodoro_timer config --url SLACK_INTEGRATION_URL_HERE
 # slack_pomodoro_timer config --channel CHANNEL_HERE
-# slack_pomodoro_timer config --integration_type CHANNEL_HERE
 
 # Running the timer
-# slack_pomodoro_timer start --pomodoros 3 --seconds 100
-# slack_pomodoro_timer start --pomodoros 3 --minutes 30
-# slack_pomodoro_timer start --pomodoros 3 --hours 1
-# slack_pomodoro_timer start --pomodoros 3 --minutes 30 --channel #general
+# slack_pomodoro_timer start 5
+
+# default timer is 25 minutes, to override:
+# slack_pomodoro_timer start 6 --minutes 30
 
 
 module SlackPomodoroTimer
@@ -43,12 +42,10 @@ module SlackPomodoroTimer
 
 
     desc 'start COUNT [OPTIONS]', 'set the number of pomodoros and time interval here'
-    option :seconds, aliases: :s, type: :numeric
-    option :minutes, aliases: :m, type: :numeric
-    option :hours, aliases: :h, type: :numeric
+    option :minutes, aliases: :m, type: :numeric, default: 25
     def start(pomodoros)
       if Config.configured?
-        interval_in_seconds = options[:seconds]
+        interval_in_seconds = options[:minutes] * 60
         Pomodorobot.start_timer(pomodoros, interval_in_seconds)
       else
         puts "Not Configured."

--- a/lib/slack_pomodoro_timer/timer.rb
+++ b/lib/slack_pomodoro_timer/timer.rb
@@ -52,15 +52,13 @@ module SlackPomodoroTimer
     end
 
     def format_countdown(seconds)
-      hours = seconds / 60 / 60
       minutes = (seconds / 60).to_s.rjust(2,"0")
+      while seconds >= 60
+        seconds-= 60
+      end
       seconds = seconds.to_s.rjust(2,"0")
 
-      if hours >= 1
-        "#{display_pomodoro_status} -- #{hours}:#{minutes}:#{seconds}"
-      else
-        "#{display_pomodoro_status} -- #{minutes}:#{seconds}"
-      end
+      "#{display_pomodoro_status} -- #{minutes}:#{seconds}"
     end
 
     def current_time

--- a/spec/slack_pomodoro_timer/http_spec.rb
+++ b/spec/slack_pomodoro_timer/http_spec.rb
@@ -37,5 +37,3 @@ describe SlackPomodoroTimer::HTTP do
   end
 
 end
-
-


### PR DESCRIPTION
Removing the hours and seconds allows us to have a default interval of 25 minutes.

If people are setting Pomodoros for multiple hours, then they are doing it wrong. And configuring for seconds, while useful in tests, seems kinda silly.
